### PR TITLE
Fix invalid localWorkSize and globalWorkOffset

### DIFF
--- a/conformance/bindingTesting/queues/cl_commandQueue_enqueueNDRangeKernel.html
+++ b/conformance/bindingTesting/queues/cl_commandQueue_enqueueNDRangeKernel.html
@@ -80,9 +80,9 @@ try {
     shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, null, globalWorkSize, null);");
 
     // Testing for nullable parameters.
-    shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, null, globalWorkSize, []);");
-    shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, [], globalWorkSize, null);");
     shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, null, globalWorkSize, null);");
+    shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, null, globalWorkSize, localWorkSize);");
+    shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, globalWorkSize, null);");
     shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, globalWorkSize, localWorkSize, []);");
     shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, globalWorkSize, localWorkSize, [], null);");
     shouldBeUndefined("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, globalWorkSize, localWorkSize, null);");


### PR DESCRIPTION
Empty array [] is not acceptable as localWorkSize or globalWorkOffset in enqueueNDRangeKernel, replacing them with null.
