### PR TITLE
Passing null for globalWorkSize should throw TypeError

### DIFF
--- a/conformance/bindingTesting/queues/cl_commandQueue_enqueueNDRangeKernel.html
+++ b/conformance/bindingTesting/queues/cl_commandQueue_enqueueNDRangeKernel.html
@@ -106,7 +106,8 @@ try {
     shouldThrowExceptionName("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, [10, 10, 10], globalWorkSize, localWorkSize);", "INVALID_GLOBAL_OFFSET");
     shouldThrowExceptionName("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, [Math.pow(2,32), 1], globalWorkSize, localWorkSize);", "INVALID_GLOBAL_OFFSET");
 
-    shouldThrowExceptionName("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, null, localWorkSize);", "INVALID_GLOBAL_WORK_SIZE");
+    shouldThrowTypeError("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, null, localWorkSize);");
+    shouldThrowExceptionName("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, [], localWorkSize);", "INVALID_GLOBAL_WORK_SIZE");
     shouldThrowExceptionName("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, [10], localWorkSize);", "INVALID_GLOBAL_WORK_SIZE");
     shouldThrowExceptionName("webCLCommandQueue.enqueueNDRangeKernel(webCLKernel, workDim, globalWorkOffset, [Math.pow(2,32), 2], localWorkSize);", "INVALID_GLOBAL_WORK_SIZE");
 


### PR DESCRIPTION
In JavaScript, TypeError should be thrown when an argument is not of the expected type. Since `globalWorkSize` is not declared nullable, passing `null` should cause a TypeError (as opposed to `INVALID_GLOBAL_WORK_SIZE`).
