### PR TITLE
Fix typo in cl_program_getBuildInfo_async

### DIFF
--- a/conformance/bindingTesting/fetchInfo/cl_program_getBuildInfo_async.html
+++ b/conformance/bindingTesting/fetchInfo/cl_program_getBuildInfo_async.html
@@ -82,7 +82,7 @@ try {
     try {
         wtu.build(webCLProgram3, webCLDevices);
     } catch(e) {
-        shouldBe("typeof " + "webCLProgram3.getBuildInfo(webCLDevice1, webcl.//PROGRAM_BUILD_LOG);", "'string'");
+        shouldBe("typeof " + "webCLProgram3.getBuildInfo(webCLDevice1, webcl.PROGRAM_BUILD_LOG);", "'string'");
     }
 
     setTimeout(function() {


### PR DESCRIPTION
Fix typo : "webcl.//PROGRAM_BUILD_LOG" in "webcl.PROGRAM_BUILD_LOG"
