### PR TITLE
Add missing allocations.

### DIFF
--- a/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLBuffer.html
+++ b/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLBuffer.html
@@ -51,6 +51,7 @@ try {
     var glContext = canvas.getContext("experimental-webgl");
     var glBuffer = clgl.createBuffer(glContext);
     clgl.bindBuffer(glContext, glContext.ARRAY_BUFFER, glBuffer);
+    glContext.bufferData(glContext.ARRAY_BUFFER, new Uint8Array(10), glContext.STATIC_DRAW);
 
     var webCLContext = wtu.createContext();
     shouldThrowExceptionName("webCLContext.createFromGLBuffer(webcl.MEM_READ_ONLY, glBuffer);", "WEBCL_EXTENSION_NOT_ENABLED");

--- a/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLTexture.html
+++ b/conformance/extension/KHR_gl_sharing/bindingTesting/cl_context_createFromGLTexture.html
@@ -62,6 +62,7 @@ try {
     var glTexture = clgl.createTexture(glContext);
     clgl.bindTexture(glContext, glContext.TEXTURE_2D, glTexture);
     var mipLevel = 0;
+    glContext.texImage2D(glContext.TEXTURE_2D, 0, glContext.RGBA, glContext.RGBA, glContext.UNSIGNED_BYTE, canvas);
     shouldBeType("webCLGLContext.createFromGLTexture(webcl.MEM_READ_ONLY, glContext.TEXTURE_2D, mipLevel, glTexture);", "WebCLImage");
     shouldBeType("webCLGLContext.createFromGLTexture(webcl.MEM_WRITE_ONLY, glContext.TEXTURE_2D, mipLevel, glTexture);", "WebCLImage");
     shouldBeType("webCLGLContext.createFromGLTexture(webcl.MEM_READ_WRITE, glContext.TEXTURE_2D, mipLevel, glTexture);", "WebCLImage");

--- a/conformance/extension/KHR_gl_sharing/bindingTesting/cl_memoryObject_getGLObjectInfo.html
+++ b/conformance/extension/KHR_gl_sharing/bindingTesting/cl_memoryObject_getGLObjectInfo.html
@@ -58,6 +58,7 @@ try {
 
     var glBuffer = clgl.createBuffer(glContext);
     clgl.bindBuffer(glContext, glContext.ARRAY_BUFFER, glBuffer);
+    glContext.bufferData(glContext.ARRAY_BUFFER, new Uint8Array(10), glContext.STATIC_DRAW);
     var webCLBufferMemoryObject = clgl.createFromGLBuffer(webCLGLContext, webcl.MEM_READ_ONLY, glBuffer);
     shouldBeType("webCLBufferMemoryObject.getGLObjectInfo();", "WebCLGLObjectInfo");
     shouldBeType("webCLBufferMemoryObject.getGLObjectInfo().glObject;", "WebGLBuffer");
@@ -78,6 +79,7 @@ try {
     var glTexture = clgl.createTexture(glContext);
     clgl.bindTexture(glContext, glContext.TEXTURE_2D, glTexture);
     var miplevel = 1;
+    glContext.texImage2D(glContext.TEXTURE_2D, 0, glContext.RGBA, glContext.RGBA, glContext.UNSIGNED_BYTE, canvas);
     var webCLTextureMemoryObject = clgl.createFromGLTexture(webCLGLContext, webcl.MEM_READ_ONLY, glContext.TEXTURE_2D, miplevel, glTexture);
     shouldBeType("webCLTextureMemoryObject.getGLObjectInfo();", "WebCLGLObjectInfo");
     shouldBeType("webCLTextureMemoryObject.getGLObjectInfo().glObject;", "WebGLTexture");


### PR DESCRIPTION
Memory should be allocated before buffer and texture used.
