### PR TITLE
Fix localWorkSize isn't less than or equal to globalWorkSize issue.

### DIFF
--- a/conformance/functionalityTesting/basics/createKernelsInProgram.html
+++ b/conformance/functionalityTesting/basics/createKernelsInProgram.html
@@ -116,7 +116,7 @@ try {
             wtu.setArg(kernelCopy, 1, output);
 
             globalWorkSize = [SIZE];
-            localWorkSize = [kernelCopy.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelCopy.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelCopy, globalWorkSize.length, null, globalWorkSize, localWorkSize);
             wtu.enqueueReadBuffer(webCLCommandQueue, output, true, 0, BUFFER_SIZE, resultInt);
 
@@ -148,7 +148,7 @@ try {
             wtu.setArg(kernelSquare, 2, new Uint32Array([count]));
 
             globalWorkSize = [SIZE];
-            localWorkSize = [kernelSquare.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelSquare.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelSquare, globalWorkSize.length, null , globalWorkSize, localWorkSize);
             wtu.enqueueReadBuffer(webCLCommandQueue, output, true, 0, BUFFER_SIZE, resultFloat);
 
@@ -187,7 +187,7 @@ try {
             wtu.setArg(kernelFloatToInt, 1, output);
 
             globalWorkSize = [SIZE];
-            localWorkSize = [kernelFloatToInt.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelFloatToInt.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelFloatToInt, globalWorkSize.length, null, globalWorkSize, localWorkSize);
             wtu.enqueueReadBuffer(webCLCommandQueue, output, true, 0, BUFFER_SIZE, resultInt);
 
@@ -240,9 +240,9 @@ try {
             wtu.setArg(kernelFloatToInt, 1, outputIntBuffer);
 
             globalWorkSize = [SIZE];
-            localWorkSize = [kernelSquare.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelSquare.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelSquare, globalWorkSize.length, null, globalWorkSize, localWorkSize);
-            localWorkSize = [kernelFloatToInt.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelFloatToInt.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelFloatToInt, globalWorkSize.length, null, globalWorkSize, localWorkSize);
             wtu.enqueueReadBuffer(webCLCommandQueue, outputSquareBuffer, true, 0, BUFFER_SIZE, resultFloat);
             wtu.enqueueReadBuffer(webCLCommandQueue, outputIntBuffer, true, 0, BUFFER_SIZE, resultInt);
@@ -306,9 +306,9 @@ try {
             wtu.setArg(kernelSample_test2, 1, outputSample_test2);
 
             globalWorkSize = [SIZE];
-            localWorkSize = [kernelSample_test.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelSample_test.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelSample_test, globalWorkSize.length, null, globalWorkSize, localWorkSize);
-            localWorkSize = [kernelSample_test2.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            localWorkSize = [gcd(kernelSample_test2.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
             wtu.enqueueNDRangeKernel(webCLCommandQueue, kernelSample_test2, globalWorkSize.length, null , globalWorkSize, localWorkSize);
             wtu.enqueueReadBuffer(webCLCommandQueue, outputSample_test, true, 0, BUFFER_SIZE, resultInt);
             wtu.enqueueReadBuffer(webCLCommandQueue, outputSample_test2, true, 0, BUFFER_SIZE, resultFloat);

--- a/conformance/functionalityTesting/buildingAndRunning/buildOptions.html
+++ b/conformance/functionalityTesting/buildingAndRunning/buildOptions.html
@@ -94,7 +94,7 @@ try {
             wtu.setArg(webCLKernel, 1, output);
 
             var globalWorkSize = [SIZE];
-            var localWorkSize = [webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+            var localWorkSize = [gcd(webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
 
             wtu.enqueueNDRangeKernel(webCLCommandQueue, webCLKernel, globalWorkSize.length, null, globalWorkSize, localWorkSize);
 

--- a/conformance/functionalityTesting/buildingAndRunning/setArg_local.html
+++ b/conformance/functionalityTesting/buildingAndRunning/setArg_local.html
@@ -65,7 +65,7 @@ try {
     webCLCommandQueue.enqueueWriteBuffer(input, true, 0, BUFFER_SIZE, data);
 
     globalWorkSize = [count];
-    localWorkSize = [webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+    localWorkSize = [gcd(webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), count)];
 
     webCLKernel.setArg(0, input);
     webCLKernel.setArg(1, output);

--- a/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferUsingKernel.html
+++ b/conformance/functionalityTesting/enqueueOperations/enqueueReadBufferUsingKernel.html
@@ -50,7 +50,7 @@ var executeKernel = function (webCLContext, kernelName, webCLDevices, webCLComma
         wtu.setArg(webCLKernel, 0, webCLBuffer);
 
         var globalWorkSize = [SIZE];
-        var localWorkSize = [webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+        var localWorkSize = [gcd(webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
 
         wtu.enqueueNDRangeKernel(webCLCommandQueue, webCLKernel, globalWorkSize.length, null, globalWorkSize, localWorkSize);
         wtu.enqueueReadBuffer(webCLCommandQueue, webCLBuffer, true, 0, resultDataType.length * resultDataType.BYTES_PER_ELEMENT, resultDataType);

--- a/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferUsingKernel.html
+++ b/conformance/functionalityTesting/enqueueOperations/enqueueWriteBufferUsingKernel.html
@@ -55,7 +55,7 @@ var executeKernel = function (webCLContext, kernelName, webCLDevices, webCLComma
         wtu.setArg(webCLKernel, 1, output);
 
         var globalWorkSize = [SIZE];
-        var localWorkSize = [webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE)];
+        var localWorkSize = [gcd(webCLKernel.getWorkGroupInfo(webCLDevices[0], webcl.KERNEL_WORK_GROUP_SIZE), SIZE)];
         wtu.enqueueNDRangeKernel(webCLCommandQueue, webCLKernel, globalWorkSize.length, null, globalWorkSize, localWorkSize);
         wtu.enqueueReadBuffer(webCLCommandQueue, output, true, 0, SIZE * data.BYTES_PER_ELEMENT, result);
         correct = 0;

--- a/resources/js-test-pre.js
+++ b/resources/js-test-pre.js
@@ -145,6 +145,13 @@ function testFailed(msg)
         debug('<span><span class="fail">FAIL</span> ' + escapeHTML(msg) + '</span>');
 }
 
+function gcd(_n, _m)
+{
+    if (_m == 0)
+        return _n;
+    return gcd(_m, _n % _m);
+}
+
 function areArraysEqual(_a, _b)
 {
     try {


### PR DESCRIPTION
In the OpenCL, any value in localWorkSize should be less than the value
in globalWorkSize with the same index, what's more, it's dividable
by the value in globalWorkSize.

So take the Greatest Common Divisor of the value of globalWorkSize and
the value from |KERNEL_WORK_GROUP_SIZE| as the value in localWorkSize.
