### PR TITLE
Fix invalid case in the setCallback_andReleaseEvent.html.

### DIFF
--- a/conformance/functionalityTesting/events/setCallback_andReleaseEvent.html
+++ b/conformance/functionalityTesting/events/setCallback_andReleaseEvent.html
@@ -57,7 +57,6 @@ try {
 
     wtu.setCallback(webCLUserEvent, webcl.COMPLETE, callbackNeverToBeCalled);
 
-    wtu.setStatus(webCLUserEvent, webcl.COMPLETE);
     wtu.release(webCLUserEvent);
 
     //  Calling callback on WebCLEvent and immediately releasing WebCLEvent.


### PR DESCRIPTION
If set event's status with webcl.COMPLETE, the callback will be triggered
before it's released, which breaks the consumption.
