### PR TITLE
Fix cl_memoryObject_getGLObjectInfo type checking error

### DIFF
--- a/conformance/extension/KHR_gl_sharing/bindingTesting/cl_memoryObject_getGLObjectInfo.html
+++ b/conformance/extension/KHR_gl_sharing/bindingTesting/cl_memoryObject_getGLObjectInfo.html
@@ -60,6 +60,7 @@ try {
     clgl.bindBuffer(glContext, glContext.ARRAY_BUFFER, glBuffer);
     glContext.bufferData(glContext.ARRAY_BUFFER, new Uint8Array(10), glContext.STATIC_DRAW);
     var webCLBufferMemoryObject = clgl.createFromGLBuffer(webCLGLContext, webcl.MEM_READ_ONLY, glBuffer);
+    var WebCLGLObjectInfo = Object;
     shouldBeType("webCLBufferMemoryObject.getGLObjectInfo();", "WebCLGLObjectInfo");
     shouldBeType("webCLBufferMemoryObject.getGLObjectInfo().glObject;", "WebGLBuffer");
     shouldBe("webCLBufferMemoryObject.getGLObjectInfo().type", "webcl.GL_OBJECT_BUFFER");


### PR DESCRIPTION
It looks Same as the issue in https://github.com/KhronosGroup/WebCL-conformance/commit/ba9de8a4e77289feb00d4c7a14f9a97ef04b57f6
WebCLGLObjectInfo is dictionary, not the interface in idl.