### PR TITLE
Add exception handling in cl_kernel_getArgInfo_async

### DIFF
--- a/conformance/bindingTesting/programAndKernel/cl_kernel_getArgInfo_async.html
+++ b/conformance/bindingTesting/programAndKernel/cl_kernel_getArgInfo_async.html
@@ -168,6 +168,7 @@ try {
     wtu.build(webCLProgram1, webCLDevices, '', callback1);
 
     setTimeout(function() {
+      try {
         if (!callbackFlag1)
             testFailed("webCLProgram1 did not call callback, as expected.");
 
@@ -186,7 +187,11 @@ try {
 
             wtu.appendPostJSToHTML(document);
         }, 2000);
-
+      } catch (e) {
+        testFailed(e.description);
+        notifyFinishedToHarness();
+        wtu.appendPostJSToHTML(document);
+      }
     }, 2000);
 
 } catch (e) {


### PR DESCRIPTION
Exceptions that occur in asynchronous functions, such as setTimeout, can not be caught in an external try-catch statement.
If the code in setTimeout throws an exception, the test no longer proceeds and a timeout occurs.
Add try-catch syntax to check for exceptions internally.