### PR TITLE
Fix argument type error in cl_program_build

### DIFF
--- a/conformance/extension/KHR_fp16/bindingTesting/cl_program_build.html
+++ b/conformance/extension/KHR_fp16/bindingTesting/cl_program_build.html
@@ -54,7 +54,7 @@ try {
     var webCLProgramAfterEnablingExtension = wtu.createProgram(webCLContext, kernelSource);
     var deviceFP16 = wtu.select_FP16_device(webCLDevices);
     if(deviceFP16) {
-        shouldBeUndefined("webCLProgramAfterEnablingExtension.build(deviceFP16);");
+        shouldBeUndefined("webCLProgramAfterEnablingExtension.build([deviceFP16]);");
     }
     else {
         debug("KHR_fp16 extension not supported on this machine");


### PR DESCRIPTION
https://www.khronos.org/registry/webcl/specs/latest/1.0/#WEBCLPROGRAM
The first argument in the WebCL specification must be an array type.